### PR TITLE
App Store link improvement

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
                         <h3>Mobile Downloads</h3>
                         <div class="actions-mobile">
                             <a href="https://play.google.com/store/apps/details?id=co.nano.nanowallet" class="btn-google-play"><img src="img/btn-google-play.png" /></a>
-                            <a href="http://appstore.com/nanowalletforios" class="btn-apple-store"><img src="img/btn-apple-store.png" /></a>
+                            <a href="https://appstore.com/nanowalletforios" class="btn-apple-store"><img src="img/btn-apple-store.png" /></a>
                         </div>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
                         <h3>Mobile Downloads</h3>
                         <div class="actions-mobile">
                             <a href="https://play.google.com/store/apps/details?id=co.nano.nanowallet" class="btn-google-play"><img src="img/btn-google-play.png" /></a>
-                            <a href="https://itunes.apple.com/us/app/nano-wallet-for-ios/id1373912752?mt=8" class="btn-apple-store"><img src="img/btn-apple-store.png" /></a>
+                            <a href="http://appstore.com/nanowalletforios" class="btn-apple-store"><img src="img/btn-apple-store.png" /></a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Updated link for app store from https://itunes.apple.com/us/app/nano-wallet-for-ios/id1373912752?mt=8 to https://appstore.com/nanowalletforios.

Original link would take you to the app store website, which requires additional steps to get to download functionality.  New link sends user directly to the app store for download.